### PR TITLE
Skip more files in the VS Code launch config

### DIFF
--- a/configs/node-template.json
+++ b/configs/node-template.json
@@ -7,7 +7,10 @@
   "skipFiles": [
     "<node_internals>/**",
     "**/node_modules/@temporalio/worker/src/**",
-    "**/node_modules/@temporalio/worker/lib/**"
+    "**/node_modules/@temporalio/worker/lib/**",
+    "**/node_modules/@temporalio/common/src/**",
+    "**/node_modules/@temporalio/common/lib/**",
+    "**/node_modules/**/source-map/**"
   ],
   "internalConsoleOptions": "openOnSessionStart",
   "pauseForSourceMap": true


### PR DESCRIPTION
Some recent update to either the SDK code or its dependencies or VS Code itself (unsure what the root cause is) broke the debugger's ability to jump straight to the workflow code, this configuration change fixes that.

It's a bit slower now to reach user code than before, I'll keep looking into how we can improve the slowness.