### PR TITLE
Show event ID in history view

### DIFF
--- a/webview/src/utilities/label-text-for-history-event.spec.ts
+++ b/webview/src/utilities/label-text-for-history-event.spec.ts
@@ -19,7 +19,7 @@ describe("labelTextForHistoryEvent", () => {
   it("should format the event type name with the workflow type name for a WorkflowExecutionStarted event", () => {
     const workflowExecutionStartedEvent = workflowTasks[0].events[0]
     expect(labelTextForHistoryEvent(workflowExecutionStartedEvent)).toBe(
-      "WorkflowExecutionStarted (workflow.completion)",
+      "[1] WorkflowExecutionStarted (workflow.completion)",
     )
   })
 })

--- a/webview/src/utilities/label-text-for-history-event.ts
+++ b/webview/src/utilities/label-text-for-history-event.ts
@@ -1,6 +1,6 @@
 import humanizeDuration from "humanize-duration"
 import { temporal } from "@temporalio/proto"
-import { tsToDate } from "@temporalio/common"
+import { optionalTsToMs } from "@temporalio/common/lib/time"
 import type { CategorizedEvent } from "../lib"
 
 function labelDetailsForHistoryEvent(event: CategorizedEvent) {
@@ -12,7 +12,7 @@ function labelDetailsForHistoryEvent(event: CategorizedEvent) {
     case temporal.api.enums.v1.EventType.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED:
       return `(${event.workflowExecutionSignaledEventAttributes?.signalName})`
     case temporal.api.enums.v1.EventType.EVENT_TYPE_TIMER_STARTED:
-      return `⏱ (${humanizeDuration(tsToDate(event.timerStartedEventAttributes?.startToFireTimeout!).getTime())})`
+      return `⏱ (${humanizeDuration(optionalTsToMs(event.timerStartedEventAttributes?.startToFireTimeout) ?? 0)})`
     case temporal.api.enums.v1.EventType.EVENT_TYPE_TIMER_FIRED:
       return `⏱🔥`
     case temporal.api.enums.v1.EventType.EVENT_TYPE_TIMER_CANCELED:
@@ -21,7 +21,7 @@ function labelDetailsForHistoryEvent(event: CategorizedEvent) {
 }
 
 export function labelTextForHistoryEvent(event: CategorizedEvent): string {
-  const { eventType } = event
+  const { eventId, eventType } = event
 
   if (eventType === undefined || eventType === null) {
     throw new TypeError("Expected history event `eventType` to be defined")
@@ -34,5 +34,5 @@ export function labelTextForHistoryEvent(event: CategorizedEvent): string {
     .join("")
   const details = labelDetailsForHistoryEvent(event)
 
-  return `${eventTypeName} ${details ?? ""}`
+  return `[${eventId}] ${eventTypeName} ${details ?? ""}`
 }

--- a/webview/src/views/history.svelte
+++ b/webview/src/views/history.svelte
@@ -68,7 +68,7 @@
         <p>Workflow Task ({workflowTask.status})</p>
       </div>
       {#each workflowTask.events as event}
-        <li>
+        <li title={`event ID: ${event.eventId}`}>
           {#if event?.category === "COMMAND"}
             <Icon name="arrow-left" />
           {:else}

--- a/webview/src/views/history.svelte
+++ b/webview/src/views/history.svelte
@@ -68,7 +68,7 @@
         <p>Workflow Task ({workflowTask.status})</p>
       </div>
       {#each workflowTask.events as event}
-        <li title={`event ID: ${event.eventId}`}>
+        <li title={`Event ID: ${event.eventId}`}>
           {#if event?.category === "COMMAND"}
             <Icon name="arrow-left" />
           {:else}


### PR DESCRIPTION
This is what it looks like (note that the mouse cursor isn't showing because I moved it to take the snapshot).

<img width="303" alt="image" src="https://github.com/temporalio/vscode-debugger-extension/assets/52304/bc7137f5-bf1a-49aa-a2f0-26e36f8ad79c">
